### PR TITLE
remove object from path to refunds call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headspace/zuora-request-service",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A client to interact with the zuora rest api",
   "main": "index.js",
   "scripts": {

--- a/zuora-api/refunds.js
+++ b/zuora-api/refunds.js
@@ -8,5 +8,5 @@ module.exports = {
   create: (requestOptions) => request('POST', `object/refund`, requestOptions),
 
   // https://www.zuora.com/developer/api-reference/#operation/GET_Refunds
-  getRefunds: () => request('GET', `object/refunds`),
+  getRefunds: () => request('GET', `refunds`),
 };

--- a/zuora-api/test/refunds.test.js
+++ b/zuora-api/test/refunds.test.js
@@ -31,6 +31,6 @@ describe('refunds', function() {
 
   it('getRefunds calls proxy request is called correctly', function() {
     refunds.getRefunds();
-    expect(requestStub).to.have.been.calledWithExactly('GET', 'object/refunds');
+    expect(requestStub).to.have.been.calledWithExactly('GET', 'refunds');
   });
 });


### PR DESCRIPTION
- Removes `object` from the `object/refunds` call because it is the incorrect path to call.
- Refactored tests to reflect this change