### PR TITLE
remove getRefund call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@headspace/zuora-request-service",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A client to interact with the zuora rest api",
   "main": "index.js",
   "scripts": {

--- a/zuora-api/refunds.js
+++ b/zuora-api/refunds.js
@@ -6,7 +6,4 @@ module.exports = {
 
   // https://www.zuora.com/developer/api-reference/#operation/Object_POSTRefund
   create: (requestOptions) => request('POST', `object/refund`, requestOptions),
-
-  // https://www.zuora.com/developer/api-reference/#operation/GET_Refunds
-  getRefunds: () => request('GET', `refunds`),
 };

--- a/zuora-api/test/refunds.test.js
+++ b/zuora-api/test/refunds.test.js
@@ -28,9 +28,4 @@ describe('refunds', function() {
     refunds.create(requestOptionsStub);
     expect(requestStub).to.have.been.calledWithExactly('POST', 'object/refund', requestOptionsStub);
   });
-
-  it('getRefunds calls proxy request is called correctly', function() {
-    refunds.getRefunds();
-    expect(requestStub).to.have.been.calledWithExactly('GET', 'refunds');
-  });
 });


### PR DESCRIPTION
I initially thought that we would need to use Zuora's getRefunds call .. but it turns out we can just query on the actions object. We don't even have permission from Zuora to make this call, so I'm extracting it from our codebase.

Changes: 

- Remove getRefund call and tests